### PR TITLE
Fix AttributeError

### DIFF
--- a/conoha/cli.py
+++ b/conoha/cli.py
@@ -437,7 +437,8 @@ class NetworkCommand():
 		else:
 			yield ['Direction', 'EtherType', 'RangeMin', 'RangeMax', 'Protocol', 'RemoteIPPrefix']
 		# Body
-		for rule in sg.rules:
+		rules = sg is not None and sg.rules or []
+		for rule in rules:
 			if args.verbose:
 				yield [rule.id_, rule.direction, rule.ethertype, rule.rangeMin, rule.rangeMax, rule.protocol, rule.remoteIPPrefix]
 			else:


### PR DESCRIPTION
'NoneType' object has no attribute 'rules' when security group is not found

```
[root@dockerHost conoha]# conoha-cli network list-rules
Traceback (most recent call last):
  File "/usr/local/bin/conoha-cli", line 11, in <module>
    load_entry_point('conoha-cli==0.1.1', 'console_scripts', 'conoha-cli')()
  File "/usr/local/lib/python3.6/site-packages/conoha/cli.py", line 118, in main
    parsed_args.func(token, parsed_args)
  File "/usr/local/lib/python3.6/site-packages/conoha/cli.py", line 80, in wrapper
    print(tabulate(output, headers='firstrow', tablefmt=fmt or 'simple'))
  File "/usr/local/lib/python3.6/site-packages/tabulate.py", line 1109, in tabulate
    tabular_data, headers, showindex=showindex)
  File "/usr/local/lib/python3.6/site-packages/tabulate.py", line 749, in _normalize_tabular_data
    rows = list(tabular_data)
  File "/usr/local/lib/python3.6/site-packages/conoha/cli.py", line 440, in listRules
    for rule in sg.rules:
AttributeError: 'NoneType' object has no attribute 'rules'
```